### PR TITLE
Fix DAX DISTINCTCOUNT queries

### DIFF
--- a/spice_adbc/SqlGenerator.pqm
+++ b/spice_adbc/SqlGenerator.pqm
@@ -212,7 +212,7 @@ let
 
 // This is helper function which is used in dates override function. Please see below for usage
 
-    GetListCount = (listvalue) => List.Count(listvalue),   
+    GetListCount = (listvalue) => if listvalue = null then 0 else List.Count(listvalue),   
     GetListContains = (listvalue,value) => List.Contains(listvalue,value),
     DateStartOfHelper = (args,visitor,datetimepart) =>                                                       
         let 
@@ -332,31 +332,20 @@ let
                 result
         else ...,
     
-    ListCountHelper = (visitor, ast) => 
+    ListCountHelper = (visitor, ast) =>
         let
             foldedArg = visitor(ast[Arguments]{0}),
             arg = GetArgumentForListCount(ast,visitor,true),
             withCount = InvocationWithType(arg[ArgumentAst], "Count",integerTypeWithFacets)
         in 
-            if arg[CountNull] = true
-            then 
-                let 
-                    whencondition = BinaryLogicalOperation("Equals",arg[ColumnAst],Literal("null")),
-                    whenItem =WhenItem(whencondition,one,Number.Type),
-                    case = CaseFunction({whenItem},zero,null,Number.Type),
-                    max = InvocationWithType({Argument(case,integerTypeWithFacets)},"max",integerTypeWithFacets),
-                    result = BinaryOperation(withCount,"Add",max)
-                in 
-                    result
-            else 
-                withCount,
+            withCount,
 
 //NativeTypesWithFacets ---This is specific to data connector
     textTypeWithFacets = Type.ReplaceFacets(Text.Type, [NativeTypeName = "VARCHAR"]),
     doubleTypeWithFacets = Type.ReplaceFacets(Double.Type, [NativeTypeName = "DOUBLE"]),
     decimalTypeWithFacets = Type.ReplaceFacets(Decimal.Type, [NativeTypeName = "DECIMAL"]),
     decimalTypeWithPrecision = Type.ReplaceFacets(Decimal.Type, [NativeTypeName = "DECIMAL", NumericPrecisionBase = 10, NumericPrecision = 38, NumericScale = 6]),
-    integerTypeWithFacets = Type.ReplaceFacets(Int32.Type, [NativeTypeName = "INTEGER"]),
+    integerTypeWithFacets = Type.ReplaceFacets(Number.Type, [NativeTypeName = "INTEGER"]),
     datetypewithFacets = Type.ReplaceFacets(Date.Type, [NativeTypeName = "DATE"]),
     datetimeTypeWithFacets = Type.ReplaceFacets(DateTime.Type, [NativeTypeName = "TIMESTAMP"]),
     timeTypeWithFacets = Type.ReplaceFacets(Time.Type, [NativeTypeName = "TIME"]),


### PR DESCRIPTION
## 🗣 Description

Fixes `Object reference not set to an instance of an object` error when using DAX count(distinct) queries, for example when visual/chart is configured to use `count(distinct)` aggregation for a column.

Verified that null is still correctly handled/included with this change:

```
EVALUATE
	ROW(
		"DistinctCountSUBCATEGORY_ID", CALCULATE(DISTINCTCOUNT('products'[PROD_SUBCATEGORY_ID]))
	)
```

![image](https://github.com/user-attachments/assets/aea41b9c-2366-4529-b1f4-dc629225b7c0)


Note: I would expect integer type for count / distinct count instead of double, but it seems this is the right behavior, I at least see the same query generated when using Snowflake Power BI Connector

![image](https://github.com/user-attachments/assets/48a1d750-db06-4089-aa75-104ca858612a)


## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
